### PR TITLE
Add CacheAdapterFactory to map interfaces to adapters

### DIFF
--- a/src/CacheAdapterFactory.php
+++ b/src/CacheAdapterFactory.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class CacheAdapterFactory
+ *
+ * @package LeavesAndLove\WpPsrCache
+ * @license GNU General Public License, version 2
+ * @link    https://github.com/felixarntz/wp-psr-cache
+ */
+
+namespace LeavesAndLove\WpPsrCache;
+
+use Psr\Cache\CacheItemPoolInterface as Psr6;
+use Psr\SimpleCache\CacheInterface as Psr16;
+use InvalidArgumentException;
+
+/**
+ * PSR-6 cache adapter class.
+ *
+ * @since 1.0.0
+ */
+final class CacheAdapterFactory
+{
+
+    /** @var array<string> Map interfaces to adapters. */
+    const MAPPINGS = [
+        Psr6::class  => Psr6Adapter::class,
+        Psr16::class => Psr16Adapter::class,
+    ];
+
+    /**
+     * Create a matching adapter for a given interface.
+     *
+     * @since 1.0.0
+     *
+     * @param string|object $cache Cache interface name or implementation to create an adapter for.
+     *
+     * @return CacheAdapter Adapter that matches the provided interface.
+     * @throws InvalidArgumentException If an incompatible cache implementation was provided.
+     */
+    public function create($cache): CacheAdapter
+    {
+        foreach (self::MAPPINGS as $interface => $adapter) {
+            if ((is_string($cache) && $cache === $interface)
+                || (is_object($cache) && $cache instanceof $interface)) {
+                return new $adapter;
+            }
+        }
+
+        throw new InvalidArgumentException(
+            sprintf(
+                'Incompatible cache implementation of type "%s" passed to adapter factory.',
+                is_object($cache) ? get_class($cache) : gettype($cache)
+            )
+        );
+    }
+}

--- a/src/ObjectCache.php
+++ b/src/ObjectCache.php
@@ -79,18 +79,7 @@ final class ObjectCache
      */
     public function setPersistentCache($cache)
     {
-        if (is_a($cache, Psr6::class)) {
-            $this->persistentCache = new Psr6Adapter($cache);
-        } elseif (is_a($cache, Psr16::class)) {
-            $this->persistentCache = new Psr16Adapter($cache);
-        } else {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Incompatible cache implementation of class "%s" passed for persistent cache.',
-                    get_class($cache)
-                )
-            );
-        }
+        $this->persistentCache = (new CacheAdapterFactory)->create($cache);
     }
 
     /**
@@ -104,18 +93,7 @@ final class ObjectCache
      */
     public function setNonPersistentCache($cache)
     {
-        if (is_a($cache, Psr6::class)) {
-            $this->nonPersistentCache = new Psr6Adapter($cache);
-        } elseif (is_a($cache, Psr16::class)) {
-            $this->nonPersistentCache = new Psr16Adapter($cache);
-        } else {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'Incompatible cache implementation of class "%s" passed for non-persistent cache.',
-                    get_class($cache)
-                )
-            );
-        }
+        $this->nonPersistentCache = (new CacheAdapterFactory)->create($cache);
     }
 
     /**


### PR DESCRIPTION
The logic in `ObjectCache` is messy. Deciding what adapter to use should be done in a factory.