### PR TITLE
Get rid of static object access

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,6 +8,7 @@
  */
 
 use LeavesAndLove\WpPsrCache\ObjectCache;
+use LeavesAndLove\WpPsrCache\ObjectCacheFactory;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -25,9 +26,7 @@ if ( function_exists( 'add_action' ) ) {
  * @param string|array $groups A group or an array of groups to add.
  */
 function wp_cache_add_global_groups( $groups ) {
-    $groups = (array) $groups;
-
-    ObjectCache::getInstance()->addGlobalGroups( $groups );
+	$GLOBALS['wp_object_cache']->addGlobalGroups( (array) $groups );
 }
 
 /**
@@ -39,9 +38,7 @@ function wp_cache_add_global_groups( $groups ) {
  * @param string|array $groups A group or an array of groups to add.
  */
 function wp_cache_add_network_groups( $groups ) {
-    $groups = (array) $groups;
-
-    ObjectCache::getInstance()->addNetworkGroups( $groups );
+	$GLOBALS['wp_object_cache']->addNetworkGroups( (array) $groups );
 }
 
 /**
@@ -53,9 +50,7 @@ function wp_cache_add_network_groups( $groups ) {
  * @param string|array $groups A group or an array of groups to add.
  */
 function wp_cache_add_non_persistent_groups( $groups ) {
-    $groups = (array) $groups;
-
-    ObjectCache::getInstance()->addNonPersistentGroups( $groups );
+	$GLOBALS['wp_object_cache']->addNonPersistentGroups( (array) $groups );
 }
 
 /**
@@ -67,7 +62,7 @@ function wp_cache_add_non_persistent_groups( $groups ) {
  * @param int $site_id Site ID.
  */
 function wp_cache_switch_to_site( $site_id ) {
-    ObjectCache::getInstance()->switchSiteContext( (int) $site_id );
+    $GLOBALS['wp_object_cache']->switchSiteContext( (int) $site_id );
 }
 
 /**
@@ -79,7 +74,7 @@ function wp_cache_switch_to_site( $site_id ) {
  * @param int $network_id Network ID.
  */
 function wp_cache_switch_to_network( $network_id ) {
-    ObjectCache::getInstance()->switchNetworkContext( (int) $network_id );
+    $GLOBALS['wp_object_cache']->switchNetworkContext( (int) $network_id );
 }
 
 /**
@@ -89,7 +84,12 @@ function wp_cache_switch_to_network( $network_id ) {
  * @see ObjectCache::init()
  */
 function wp_cache_init() {
-    ObjectCache::getInstance()->init( (int) get_current_blog_id(), (int) get_current_network_id() );
+	$instance = ( new ObjectCacheFactory )->create();
+	$instance->init(
+		(int) get_current_blog_id(),
+		(int) get_current_network_id()
+	);
+	$GLOBALS['wp_object_cache'] = $instance;
 }
 
 /**
@@ -106,9 +106,7 @@ function wp_cache_init() {
  * @return mixed The value of the item from the cache, or false in case of cache miss.
  */
 function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
-    $found = (bool) $found;
-
-    return ObjectCache::getInstance()->get( $key, $group, $force, $found );
+    return $GLOBALS['wp_object_cache']->get( $key, $group, $force, (bool) $found );
 }
 
 /**
@@ -124,7 +122,7 @@ function wp_cache_get( $key, $group = '', $force = false, &$found = null ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_set( $key, $value, $group = '', $expiration = 0 ) {
-    return ObjectCache::getInstance()->set( $key, $value, $group, $expiration );
+    return $GLOBALS['wp_object_cache']->set( $key, $value, $group, $expiration );
 }
 
 /**
@@ -144,7 +142,7 @@ function wp_cache_add( $key, $value, $group = '', $expiration = 0 ) {
         return false;
     }
 
-    return ObjectCache::getInstance()->add( $key, $value, $group, $expiration );
+    return $GLOBALS['wp_object_cache']->add( $key, $value, $group, $expiration );
 }
 
 /**
@@ -160,7 +158,7 @@ function wp_cache_add( $key, $value, $group = '', $expiration = 0 ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_replace( $key, $value, $group = '', $expiration = 0 ) {
-    return ObjectCache::getInstance()->replace( $key, $value, $group, $expiration );
+    return $GLOBALS['wp_object_cache']->replace( $key, $value, $group, $expiration );
 }
 
 /**
@@ -175,7 +173,7 @@ function wp_cache_replace( $key, $value, $group = '', $expiration = 0 ) {
  * @return int|bool The item's new value on success, false on failure.
  */
 function wp_cache_incr( $key, $offset = 1, $group = '' ) {
-    return ObjectCache::getInstance()->increment( $key, $offset, $group );
+    return $GLOBALS['wp_object_cache']->increment( $key, $offset, $group );
 }
 
 /**
@@ -190,7 +188,7 @@ function wp_cache_incr( $key, $offset = 1, $group = '' ) {
  * @return int|bool The item's new value on success, false on failure.
  */
 function wp_cache_decr( $key, $offset = 1, $group = '' ) {
-    return ObjectCache::getInstance()->decrement( $key, $offset, $group );
+    return $GLOBALS['wp_object_cache']->decrement( $key, $offset, $group );
 }
 
 /**
@@ -204,7 +202,7 @@ function wp_cache_decr( $key, $offset = 1, $group = '' ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_delete( $key, $group = '' ) {
-    return ObjectCache::getInstance()->delete( $key, $group );
+    return $GLOBALS['wp_object_cache']->delete( $key, $group );
 }
 
 /**
@@ -216,7 +214,7 @@ function wp_cache_delete( $key, $group = '' ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_flush() {
-    return ObjectCache::getInstance()->flush();
+    return $GLOBALS['wp_object_cache']->flush();
 }
 
 /**
@@ -241,7 +239,7 @@ function wp_cache_close() {
  * @return bool True if the value is present, false otherwise.
  */
 function wp_cache_has( $key, $group = '' ) {
-    return ObjectCache::getInstance()->has( $key, $group );
+    return $GLOBALS['wp_object_cache']->has( $key, $group );
 }
 
 /**
@@ -256,7 +254,7 @@ function wp_cache_has( $key, $group = '' ) {
  * @return array List of key => value pairs. For cache misses, false will be used as value.
  */
 function wp_cache_get_multi( $keys, $groups = '' ) {
-    return ObjectCache::getInstance()->getMultiple( $keys, $groups );
+    return $GLOBALS['wp_object_cache']->getMultiple( $keys, $groups );
 }
 
 /**
@@ -272,7 +270,7 @@ function wp_cache_get_multi( $keys, $groups = '' ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_set_multi( $values, $groups = '', $expiration = 0 ) {
-    return ObjectCache::getInstance()->setMultiple( $values, $groups, $expiration );
+    return $GLOBALS['wp_object_cache']->setMultiple( $values, $groups, $expiration );
 }
 
 /**
@@ -287,7 +285,7 @@ function wp_cache_set_multi( $values, $groups = '', $expiration = 0 ) {
  * @return bool True on success, false on failure.
  */
 function wp_cache_delete_multi( $keys, $groups = '' ) {
-    return ObjectCache::getInstance()->deleteMultiple( $keys, $groups );
+    return $GLOBALS['wp_object_cache']->deleteMultiple( $keys, $groups );
 }
 
 /**
@@ -301,7 +299,7 @@ function wp_cache_delete_multi( $keys, $groups = '' ) {
  * @return string The full cache key to use with cache implementations.
  */
 function wp_cache_get_key( $key, $group = '' ) {
-    return ObjectCache::getInstance()->buildKey( $key, $group );
+    return $GLOBALS['wp_object_cache']->buildKey( $key, $group );
 }
 
 /**

--- a/src/ObjectCache.php
+++ b/src/ObjectCache.php
@@ -764,23 +764,4 @@ final class ObjectCache
     {
         require_once dirname( __DIR__ ) . '/includes/functions.php';
     }
-
-    /**
-     * Get the main instance.
-     *
-     * This is a workaround because the static facade doesn't work here.
-     * See https://stackoverflow.com/questions/31039380/callstatic-does-not-call-if-there-exist-a-non-static-function
-     *
-     * @since 1.0.0
-     *
-     * @return static The main object cache instance.
-     */
-    public static function getInstance()
-    {
-        if (null === static::$instance) {
-            static::$instance = new static();
-        }
-
-        return static::$instance;
-    }
 }

--- a/src/ObjectCacheFactory.php
+++ b/src/ObjectCacheFactory.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Class ObjectCacheFactory
+ *
+ * @package LeavesAndLove\WpPsrCache
+ * @license GNU General Public License, version 2
+ * @link    https://github.com/felixarntz/wp-psr-cache
+ */
+
+namespace LeavesAndLove\WpPsrCache;
+
+final class ObjectCacheFactory
+{
+    /** @var ObjectCache Instance of the object cache to share. */
+    private static $instance;
+
+    /**
+     * Instantiate an ObjectCacheFactory object.
+     *
+     * @since 0.1.0
+     *
+     * @param ObjectCache|null $cache Optional. ObjectCache instance to reuse.
+     */
+    public function __construct(ObjectCache $cache = null)
+    {
+        self::$instance = $cache ?? new ObjectCache();
+    }
+
+    /**
+     * Return an instance of an object cache.
+     *
+     * @since 0.1.0
+     *
+     * @return ObjectCache
+     */
+    public function create(): ObjectCache
+    {
+        return self::$instance;
+    }
+}


### PR DESCRIPTION
This is just one possible way of getting rid of the static access.

- Adds a factory to share an object cache instance. This replaces the `getInstance()` call.
- Uses the global `$wp_object_cache`. This already exists in WordPress, and external code might expect it to be populated.